### PR TITLE
Updated nowallet/nowallet.py

### DIFF
--- a/nowallet/nowallet.py
+++ b/nowallet/nowallet.py
@@ -720,11 +720,12 @@ class Wallet:
         addr = result[0]  # type: str
         history = await self.connection.listen_rpc(
             self.methods["get_history"], [addr])  # type: List[Dict[str, Any]]
-        empty_flag = await self._interpret_new_history(
-            addr, history[0])  # type: bool
-        if not empty_flag:
-            self.new_history = True
-            logging.info("Dispatched a new history for address %s", addr)
+        for tx in history:
+            empty_flag = await self._interpret_new_history(
+                addr, tx)  # type: bool
+            if not empty_flag:
+                self.new_history = True
+                logging.info("Dispatched a new history for address %s", addr)
 
     @staticmethod
     def _calculate_vsize(tx: Tx) -> int:


### PR DESCRIPTION
## Status
READY

## Migrations
NO

## Description
The pull request resolves #12 where new spend transactions are not appearing in the transaction history. This was due to the fact that not all transactions were iterated over when requesting the history for a given address and was fixed by iterating over all transactions received from RPC call. 


## Related PRs
None

branch | PR
------ | ------
master


## Todos
None


## Deploy Notes
None

## Steps to Test or Reproduce
1. Run nowallet using any interface
2. Spend test coins
3. Wait for new tx to appear in history
4. Watch the magic happen :-)

## Impacted Areas in Application
nowallet/nowallet.py
Wallet._dispatch_result method was modified

* 
